### PR TITLE
Add missing functions to PointAlarmStatusClient interface

### DIFF
--- a/services/pas/client.go
+++ b/services/pas/client.go
@@ -32,6 +32,9 @@ type PointAlarmStatusClient interface {
 	GetPointAlarmStatus(input pas_api.GetPointAlarmStatusInput) (pas_api.AlarmStatus, error)
 	GetPointAlarmStatusWithContext(ctx context.Context, input pas_api.GetPointAlarmStatusInput) (pas_api.AlarmStatus, error)
 
+	GetPointAlarmStatusEventLog(seqID string) (events pas_api.GetPointAlarmStatusEventLogOutput, err error)
+	GetPointAlarmStatusEventLogWithContext(ctx context.Context, seqID string) (events pas_api.GetPointAlarmStatusEventLogOutput, err error)
+
 	GetPointAlarmStatusStream(dc chan<- pas_api.GetPointAlarmStatusStreamOutput) error
 	GetPointAlarmStatusStreamWithContext(ctx context.Context, dc chan<- pas_api.GetPointAlarmStatusStreamOutput) error
 

--- a/services/pas/mock/mock.go
+++ b/services/pas/mock/mock.go
@@ -76,6 +76,16 @@ func (mock *client) GetPointAlarmStatusWithContext(ctx context.Context, input pa
 	return args.Get(0).(pas_api.AlarmStatus), args.Error(1)
 }
 
+func (mock *client) GetPointAlarmStatusEventLog(seqID string) (events pas_api.GetPointAlarmStatusEventLogOutput, err error) {
+	args := mock.Called(seqID)
+	return args.Get(0).(pas_api.GetPointAlarmStatusEventLogOutput), args.Error(1)
+}
+
+func (mock *client) GetPointAlarmStatusEventLogWithContext(ctx context.Context, seqID string) (events pas_api.GetPointAlarmStatusEventLogOutput, err error) {
+	args := mock.Called(ctx, seqID)
+	return args.Get(0).(pas_api.GetPointAlarmStatusEventLogOutput), args.Error(1)
+}
+
 func (mock *client) GetPointAlarmStatusStream(dc chan<- pas_api.GetPointAlarmStatusStreamOutput) error {
 	args := mock.Called(dc)
 	return args.Error(0)


### PR DESCRIPTION
`GetPointAlarmStatusEventLog` and `GetPointAlarmStatusEventLogWithContext` were missing in the `PointAlarmStatusClient` interface. This PR fixes that.