### PR TITLE
Add linting build step & fix lint issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,42 @@
+# Reference of settings:
+# https://github.com/golangci/golangci-lint/blob/master/.golangci.example.yml
+
+# To remedy '<file>: File is not `goimports`-ed (goimports)' do:
+# goimports -w -local github.com/SKF <file>
+
+# all available settings of specific linters
+linters-settings:
+  errcheck:
+    # default is false: such cases aren't reported by default.
+    check-blank: true
+  govet:
+    # report about shadowed variables
+    check-shadowing: true
+  goimports:
+    # put imports beginning with prefix after 3rd-party packages;
+    # it's a comma-separated list of prefixes
+    local-prefixes: github.com/SKF
+  gocyclo:
+    # minimal code complexity to report, 30 by default (but we recommend 10-20)
+    min-complexity: 10
+  maligned:
+    # print struct with more effective memory layout or not, false by default
+    suggest-new: true
+  dupl:
+    # tokens count to trigger issue, 150 by default
+    threshold: 100
+
+issues:
+  # List of regexps of issue texts to exclude, empty list by default.
+  # To see excluded by default patterns execute `golangci-lint run --help`
+  exclude:
+    - don't use ALL_CAPS in Go names; use CamelCase
+
+linters:
+  enable-all: true
+  disable:
+    - depguard
+    - gochecknoinits
+    - gochecknoglobals
+    - lll
+    - prealloc

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,10 @@ go:
 sudo: false
 before_install:
   - curl https://glide.sh/get | sh
+  - curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.13.2
 install:
   - glide install
-before_script:
-  - go vet ./...
+  - golangci-lint --version
 script:
+  - golangci-lint run ./...
   - go test ./... --short

--- a/grpc/grpc.go
+++ b/grpc/grpc.go
@@ -38,20 +38,20 @@ func WithTransportCredentials(serverName, clientCert, clientKey, caCert string) 
 	certificate, err := tls.LoadX509KeyPair(clientCert, clientKey)
 
 	if err != nil {
-		err = fmt.Errorf("Failed to load client certs, %+v", err)
+		err = fmt.Errorf("failed to load client certs, %+v", err)
 		return
 	}
 
 	certPool := x509.NewCertPool()
 	bs, err := ioutil.ReadFile(caCert)
 	if err != nil {
-		err = fmt.Errorf("Failed to read ca cert, %+v", err)
+		err = fmt.Errorf("failed to read ca cert, %+v", err)
 		return
 	}
 
 	ok := certPool.AppendCertsFromPEM(bs)
 	if !ok {
-		err = errors.New("Failed to append certs")
+		err = errors.New("failed to append certs")
 		return
 	}
 

--- a/services/hierarchy/client.go
+++ b/services/hierarchy/client.go
@@ -6,15 +6,16 @@ import (
 
 	"github.com/SKF/proto/common"
 
+	"google.golang.org/grpc"
+
 	"github.com/SKF/go-eventsource/eventsource"
 	hierarchy_grpcapi "github.com/SKF/proto/hierarchy"
-	"google.golang.org/grpc"
 )
 
 // HierarchyClient provides the API operation methods for making
 // requests to Enlight Hierarchy Management Service. See this
 // package's package overview docs for details on the service.
-type HierarchyClient interface {
+type HierarchyClient interface { // nolint: golint
 	Dial(host, port string, opts ...grpc.DialOption) error
 	DialWithContext(ctx context.Context, host, port string, opts ...grpc.DialOption) error
 	Close()

--- a/services/hierarchy/functions.go
+++ b/services/hierarchy/functions.go
@@ -153,7 +153,7 @@ func (c *Client) GetAncestorsWithContext(ctx context.Context, nodeID string) (no
 	return
 }
 
-// GetEvents will return all events that has occured in the Hierarchy
+// GetEvents will return all events that has occurred in the Hierarchy
 // Management Service.
 func (c *Client) GetEvents(since int, limit *int32) (events []eventsource.Record, err error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
@@ -161,7 +161,7 @@ func (c *Client) GetEvents(since int, limit *int32) (events []eventsource.Record
 	return c.GetEventsWithContext(ctx, since, limit)
 }
 
-// GetEventsWithContext will return all events that has occured in the Hierarchy
+// GetEventsWithContext will return all events that has occurred in the Hierarchy
 // Management Service.
 func (c *Client) GetEventsWithContext(ctx context.Context, since int, limit *int32) (events []eventsource.Record, err error) {
 	input := hierarchy_grpcapi.GetEventsInput{Since: int64(since)}

--- a/services/hierarchy/mock/mock.go
+++ b/services/hierarchy/mock/mock.go
@@ -3,9 +3,10 @@ package mock
 import (
 	"context"
 
-	"github.com/SKF/go-eventsource/eventsource"
 	"github.com/stretchr/testify/mock"
 	"google.golang.org/grpc"
+
+	"github.com/SKF/go-eventsource/eventsource"
 
 	"github.com/SKF/go-enlight-sdk/services/hierarchy"
 	"github.com/SKF/proto/common"
@@ -16,7 +17,7 @@ type client struct {
 	mock.Mock
 }
 
-func Create() *client {
+func Create() *client { // nolint: golint
 	return new(client)
 }
 
@@ -34,7 +35,6 @@ func (mock *client) DialWithContext(ctx context.Context, host, port string, opts
 
 func (mock *client) Close() {
 	mock.Called()
-	return
 }
 
 func (mock *client) DeepPing() error {

--- a/services/hierarchy/models/node_sub_type.go
+++ b/services/hierarchy/models/node_sub_type.go
@@ -14,7 +14,7 @@ const (
 	NodeSubTypeInspectionPoint    NodeSubType = "inspection_point"
 )
 
-var nodeTypeClasses = map[NodeType][]NodeSubType{
+var nodeTypeClasses = map[NodeType][]NodeSubType{ // nolint
 	NodeTypeCompany:            {NodeSubTypeCompany},
 	NodeTypeSite:               {NodeSubTypeSite},
 	NodeTypePlant:              {NodeSubTypePlant, NodeSubTypeShip},

--- a/services/hierarchy/models/node_type.go
+++ b/services/hierarchy/models/node_type.go
@@ -13,7 +13,7 @@ const (
 	NodeTypeInspectionPoint    NodeType = "inspection_point"
 )
 
-var relations = map[NodeType][]NodeType{
+var relations = map[NodeType][]NodeType{ // nolint
 	NodeTypeCompany:            {NodeTypeCompany},
 	NodeTypeSite:               {NodeTypeCompany},
 	NodeTypePlant:              {NodeTypeSite},

--- a/services/iam/client.go
+++ b/services/iam/client.go
@@ -6,12 +6,13 @@ import (
 
 	"github.com/SKF/proto/common"
 
+	"google.golang.org/grpc"
+
 	"github.com/SKF/go-eventsource/eventsource"
 	iam_grpcapi "github.com/SKF/proto/iam"
-	"google.golang.org/grpc"
 )
 
-type IAMClient interface {
+type IAMClient interface { // nolint: golint
 	Dial(host, port string, opts ...grpc.DialOption) error
 	DialWithContext(ctx context.Context, host, port string, opts ...grpc.DialOption) error
 	Close()

--- a/services/iam/functions.go
+++ b/services/iam/functions.go
@@ -23,7 +23,7 @@ func (c *client) CheckAuthenticationWithContext(ctx context.Context, token, arn 
 	if output != nil {
 		claims = *output
 	} else if err == nil {
-		err = errors.New("No output")
+		err = errors.New("no output")
 	}
 	return
 }
@@ -44,7 +44,7 @@ func (c *client) CheckAuthenticationByEndpointWithContext(ctx context.Context, t
 	if output != nil {
 		claims = *output
 	} else if err == nil {
-		err = errors.New("No output")
+		err = errors.New("no output")
 	}
 	return
 }

--- a/services/iam/mock/mock.go
+++ b/services/iam/mock/mock.go
@@ -5,10 +5,11 @@ import (
 
 	"github.com/SKF/proto/common"
 
-	"github.com/SKF/go-eventsource/eventsource"
-	iam_grpcapi "github.com/SKF/proto/iam"
 	"github.com/stretchr/testify/mock"
 	"google.golang.org/grpc"
+
+	"github.com/SKF/go-eventsource/eventsource"
+	iam_grpcapi "github.com/SKF/proto/iam"
 
 	"github.com/SKF/go-enlight-sdk/services/iam"
 )
@@ -17,7 +18,7 @@ type client struct {
 	mock.Mock
 }
 
-func Create() *client {
+func Create() *client { // nolint: golint
 	return new(client)
 }
 
@@ -34,7 +35,6 @@ func (mock *client) DialWithContext(ctx context.Context, host, port string, opts
 
 func (mock *client) Close() {
 	mock.Called()
-	return
 }
 
 func (mock *client) DeepPing() error {

--- a/services/iot/client.go
+++ b/services/iot/client.go
@@ -6,11 +6,12 @@ import (
 
 	"github.com/SKF/proto/common"
 
-	iot_grpcapi "github.com/SKF/proto/iot"
 	"google.golang.org/grpc"
+
+	iot_grpcapi "github.com/SKF/proto/iot"
 )
 
-type IoTClient interface {
+type IoTClient interface { // nolint: golint
 	Dial(host, port string, opts ...grpc.DialOption) error
 	DialWithContext(ctx context.Context, host, port string, opts ...grpc.DialOption) error
 	Close()
@@ -39,8 +40,8 @@ type IoTClient interface {
 	SetTaskStatus(input iot_grpcapi.SetTaskStatusInput) (err error)
 	SetTaskStatusWithContext(ctx context.Context, input iot_grpcapi.SetTaskStatusInput) (err error)
 
-	GetTaskStream(input iot_grpcapi.GetTaskStreamInput, dc chan<- iot_grpcapi.GetTaskStreamOutput) (err error)
-	GetTaskStreamWithContext(ctx context.Context, input iot_grpcapi.GetTaskStreamInput, dc chan<- iot_grpcapi.GetTaskStreamOutput) (err error)
+	GetTaskStream(input iot_grpcapi.GetTaskStreamInput, dc chan<- iot_grpcapi.GetTaskStreamOutput) (err error)                                 // nolint: staticcheck
+	GetTaskStreamWithContext(ctx context.Context, input iot_grpcapi.GetTaskStreamInput, dc chan<- iot_grpcapi.GetTaskStreamOutput) (err error) // nolint: staticcheck
 
 	GetTasksByStatus(input iot_grpcapi.GetTasksByStatusInput) ([]*iot_grpcapi.TaskDescription, error)
 	GetTasksByStatusWithContext(ctx context.Context, input iot_grpcapi.GetTasksByStatusInput) ([]*iot_grpcapi.TaskDescription, error)

--- a/services/iot/functions.go
+++ b/services/iot/functions.go
@@ -8,9 +8,10 @@ import (
 
 	"github.com/SKF/proto/common"
 
-	iot_grpcapi "github.com/SKF/proto/iot"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	iot_grpcapi "github.com/SKF/proto/iot"
 )
 
 func (c *Client) CreateTask(task iot_grpcapi.InitialTaskDescription) (taskID string, err error) {
@@ -167,12 +168,12 @@ func (c *Client) GetTaskByUUIDWithContext(ctx context.Context, input string) (ou
 	return
 }
 
-func (c *Client) GetTaskByLongId(input int64) (output *iot_grpcapi.TaskDescription, err error) {
+func (c *Client) GetTaskByLongId(input int64) (output *iot_grpcapi.TaskDescription, err error) { // nolint: golint
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 	return c.GetTaskByLongIdWithContext(ctx, input)
 }
-func (c *Client) GetTaskByLongIdWithContext(ctx context.Context, input int64) (output *iot_grpcapi.TaskDescription, err error) {
+func (c *Client) GetTaskByLongIdWithContext(ctx context.Context, input int64) (output *iot_grpcapi.TaskDescription, err error) { // nolint: golint
 	grpcInput := iot_grpcapi.GetTaskByLongIdInput{
 		TaskId: input,
 	}
@@ -267,19 +268,19 @@ func (c *Client) RequestPutMediaSignedURL(in *iot_grpcapi.PutMediaSignedUrlInput
 	return c.RequestPutMediaSignedURLWithContext(ctx, in)
 }
 
-func (c *Client) GetTaskStream(input iot_grpcapi.GetTaskStreamInput, dc chan<- iot_grpcapi.GetTaskStreamOutput) (err error) {
+func (c *Client) GetTaskStream(input iot_grpcapi.GetTaskStreamInput, dc chan<- iot_grpcapi.GetTaskStreamOutput) (err error) { // nolint: staticcheck
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	return c.GetTaskStreamWithContext(ctx, input, dc)
 }
-func (c *Client) GetTaskStreamWithContext(ctx context.Context, input iot_grpcapi.GetTaskStreamInput, dc chan<- iot_grpcapi.GetTaskStreamOutput) (err error) {
+func (c *Client) GetTaskStreamWithContext(ctx context.Context, input iot_grpcapi.GetTaskStreamInput, dc chan<- iot_grpcapi.GetTaskStreamOutput) (err error) { // nolint: staticcheck
 	stream, err := c.api.GetTaskStream(ctx, &input)
 	if err != nil {
 		return
 	}
 
 	for {
-		var nodeData *iot_grpcapi.GetTaskStreamOutput
+		var nodeData *iot_grpcapi.GetTaskStreamOutput // nolint: staticcheck
 		nodeData, err = stream.Recv()
 		if err == io.EOF {
 			err = nil

--- a/services/iot/mock/mock.go
+++ b/services/iot/mock/mock.go
@@ -3,9 +3,10 @@ package mock
 import (
 	"context"
 
-	iot_grpcapi "github.com/SKF/proto/iot"
 	"github.com/stretchr/testify/mock"
 	"google.golang.org/grpc"
+
+	iot_grpcapi "github.com/SKF/proto/iot"
 
 	"github.com/SKF/go-enlight-sdk/services/iot"
 )
@@ -14,7 +15,7 @@ type client struct {
 	mock.Mock
 }
 
-func Create() *client {
+func Create() *client { // nolint: golint
 	return new(client)
 }
 
@@ -31,7 +32,6 @@ func (mock *client) DialWithContext(ctx context.Context, host, port string, opts
 
 func (mock *client) Close() {
 	mock.Called()
-	return
 }
 func (mock *client) DeepPing() error {
 	args := mock.Called()
@@ -105,11 +105,11 @@ func (mock *client) SetTaskStatusWithContext(ctx context.Context, input iot_grpc
 	return args.Error(0)
 }
 
-func (mock *client) GetTaskStream(input iot_grpcapi.GetTaskStreamInput, dc chan<- iot_grpcapi.GetTaskStreamOutput) error {
+func (mock *client) GetTaskStream(input iot_grpcapi.GetTaskStreamInput, dc chan<- iot_grpcapi.GetTaskStreamOutput) error { // nolint: staticcheck
 	args := mock.Called(input, dc)
 	return args.Error(0)
 }
-func (mock *client) GetTaskStreamWithContext(ctx context.Context, input iot_grpcapi.GetTaskStreamInput, dc chan<- iot_grpcapi.GetTaskStreamOutput) error {
+func (mock *client) GetTaskStreamWithContext(ctx context.Context, input iot_grpcapi.GetTaskStreamInput, dc chan<- iot_grpcapi.GetTaskStreamOutput) error { // nolint: staticcheck
 	args := mock.Called(ctx, input, dc)
 	return args.Error(0)
 }
@@ -197,11 +197,11 @@ func (mock *client) GetTaskByUUIDWithContext(ctx context.Context, input string) 
 	args := mock.Called(ctx, input)
 	return args.Get(0).(*iot_grpcapi.TaskDescription), args.Error(1)
 }
-func (mock *client) GetTaskByLongId(input int64) (output *iot_grpcapi.TaskDescription, err error) {
+func (mock *client) GetTaskByLongId(input int64) (output *iot_grpcapi.TaskDescription, err error) { // nolint: golint
 	args := mock.Called(input)
 	return args.Get(0).(*iot_grpcapi.TaskDescription), args.Error(1)
 }
-func (mock *client) GetTaskByLongIdWithContext(ctx context.Context, input int64) (output *iot_grpcapi.TaskDescription, err error) {
+func (mock *client) GetTaskByLongIdWithContext(ctx context.Context, input int64) (output *iot_grpcapi.TaskDescription, err error) { // nolint: golint
 	args := mock.Called(ctx, input)
 	return args.Get(0).(*iot_grpcapi.TaskDescription), args.Error(1)
 }

--- a/services/pas/client.go
+++ b/services/pas/client.go
@@ -36,8 +36,8 @@ type PointAlarmStatusClient interface {
 	GetPointAlarmStatusEventLog(seqID string) (events pas_api.GetPointAlarmStatusEventLogOutput, err error)
 	GetPointAlarmStatusEventLogWithContext(ctx context.Context, seqID string) (events pas_api.GetPointAlarmStatusEventLogOutput, err error)
 
-	GetPointAlarmStatusStream(dc chan<- pas_api.GetPointAlarmStatusStreamOutput) error
-	GetPointAlarmStatusStreamWithContext(ctx context.Context, dc chan<- pas_api.GetPointAlarmStatusStreamOutput) error
+	GetPointAlarmStatusStream(dc chan<- pas_api.GetPointAlarmStatusStreamOutput) error                                 // nolint: staticcheck
+	GetPointAlarmStatusStreamWithContext(ctx context.Context, dc chan<- pas_api.GetPointAlarmStatusStreamOutput) error // nolint: staticcheck
 
 	CalculateAndSetPointAlarmStatus(input pas_api.CalculateAndSetPointAlarmStatusInput) error
 	CalculateAndSetPointAlarmStatusWithContext(ctx context.Context, input pas_api.CalculateAndSetPointAlarmStatusInput) error

--- a/services/pas/functions.go
+++ b/services/pas/functions.go
@@ -68,7 +68,7 @@ func (c *Client) GetPointAlarmStatusWithContext(ctx context.Context, input pas_a
 }
 
 // GetPointAlarmStatusStream gets a stream of alarm status updates for all points
-func (c *Client) GetPointAlarmStatusStream(dc chan<- pas_api.GetPointAlarmStatusStreamOutput) error {
+func (c *Client) GetPointAlarmStatusStream(dc chan<- pas_api.GetPointAlarmStatusStreamOutput) error { // nolint: staticcheck
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	return c.GetPointAlarmStatusStreamWithContext(ctx, dc)
@@ -76,14 +76,14 @@ func (c *Client) GetPointAlarmStatusStream(dc chan<- pas_api.GetPointAlarmStatus
 }
 
 // GetPointAlarmStatusStreamWithContext gets a stream of alarm status updates for all points
-func (c *Client) GetPointAlarmStatusStreamWithContext(ctx context.Context, dc chan<- pas_api.GetPointAlarmStatusStreamOutput) (err error) {
-	stream, err := c.api.GetPointAlarmStatusStream(ctx, &pas_api.GetPointAlarmStatusStreamInput{})
+func (c *Client) GetPointAlarmStatusStreamWithContext(ctx context.Context, dc chan<- pas_api.GetPointAlarmStatusStreamOutput) (err error) { // nolint: staticcheck
+	stream, err := c.api.GetPointAlarmStatusStream(ctx, &pas_api.GetPointAlarmStatusStreamInput{}) // nolint: staticcheck
 	if err != nil {
 		return
 	}
 
 	for {
-		var output *pas_api.GetPointAlarmStatusStreamOutput
+		var output *pas_api.GetPointAlarmStatusStreamOutput // nolint: staticcheck
 		output, err = stream.Recv()
 		if err == io.EOF {
 			err = nil

--- a/services/pas/mock/mock.go
+++ b/services/pas/mock/mock.go
@@ -4,9 +4,10 @@ package mock
 import (
 	"context"
 
-	pas_api "github.com/SKF/proto/pas"
 	"github.com/stretchr/testify/mock"
 	"google.golang.org/grpc"
+
+	pas_api "github.com/SKF/proto/pas"
 
 	"github.com/SKF/go-enlight-sdk/services/pas"
 )
@@ -15,7 +16,7 @@ type client struct {
 	mock.Mock
 }
 
-func Create() *client {
+func Create() *client { // nolint: golint
 	return new(client)
 }
 
@@ -32,7 +33,6 @@ func (mock *client) DialWithContext(ctx context.Context, host, port string, opts
 
 func (mock *client) Close() {
 	mock.Called()
-	return
 }
 
 func (mock *client) DeepPing() error {
@@ -90,11 +90,11 @@ func (mock *client) GetPointAlarmStatusEventLogWithContext(ctx context.Context, 
 	return args.Get(0).(pas_api.GetPointAlarmStatusEventLogOutput), args.Error(1)
 }
 
-func (mock *client) GetPointAlarmStatusStream(dc chan<- pas_api.GetPointAlarmStatusStreamOutput) error {
+func (mock *client) GetPointAlarmStatusStream(dc chan<- pas_api.GetPointAlarmStatusStreamOutput) error { // nolint: staticcheck
 	args := mock.Called(dc)
 	return args.Error(0)
 }
-func (mock *client) GetPointAlarmStatusStreamWithContext(ctx context.Context, dc chan<- pas_api.GetPointAlarmStatusStreamOutput) error {
+func (mock *client) GetPointAlarmStatusStreamWithContext(ctx context.Context, dc chan<- pas_api.GetPointAlarmStatusStreamOutput) error { // nolint: staticcheck
 	args := mock.Called(ctx, dc)
 	return args.Error(0)
 }

--- a/services/reports/client.go
+++ b/services/reports/client.go
@@ -6,12 +6,13 @@ import (
 
 	"github.com/SKF/proto/common"
 
-	reports_grpcapi "github.com/SKF/proto/reports"
 	"google.golang.org/grpc"
+
+	reports_grpcapi "github.com/SKF/proto/reports"
 )
 
 // ReportsClient describes the exported methods on the reports service
-type ReportsClient interface {
+type ReportsClient interface { // nolint: golint
 	Dial(host, port string, opts ...grpc.DialOption) error
 	DialWithContext(ctx context.Context, host, port string, opts ...grpc.DialOption) error
 	Close()

--- a/services/reports/mock/mock.go
+++ b/services/reports/mock/mock.go
@@ -3,9 +3,10 @@ package mock
 import (
 	"context"
 
-	reports_grpcapi "github.com/SKF/proto/reports"
 	"github.com/stretchr/testify/mock"
 	"google.golang.org/grpc"
+
+	reports_grpcapi "github.com/SKF/proto/reports"
 
 	"github.com/SKF/go-enlight-sdk/services/reports"
 )
@@ -14,7 +15,7 @@ type client struct {
 	mock.Mock
 }
 
-func Create() *client {
+func Create() *client { // nolint: golint
 	return new(client)
 }
 
@@ -31,7 +32,6 @@ func (mock *client) DialWithContext(ctx context.Context, host, port string, opts
 
 func (mock *client) Close() {
 	mock.Called()
-	return
 }
 
 func (mock *client) DeepPing() (output *reports_grpcapi.DeepPingOutput, err error) {


### PR DESCRIPTION
Nolint directives for staticcheck are due to use of deprecated gRPC
message types.
Nolint directives for golint are due to naming conventions (e.g. Id vs
ID).