### PR TITLE
Connect sdk to proto change - Add external sensor

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -4,7 +4,7 @@ import:
     subpackages:
       - log
   - package: github.com/SKF/proto
-    version: v1.8.2-go
+    version: v1.8.3-go
   - package: github.com/golang/protobuf
     version: v1.2.0
     subpackages:


### PR DESCRIPTION
New version of proto is: 1.8.3