### PR TITLE
#39694 - renaming functions

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,22 @@
 
 
 [[projects]]
+  digest = "1:783b072ef30e413faaf6d2c95af2c2f4c32d5283c01fce335e0a89c501564abc"
+  name = "github.com/SKF/go-enlight-sdk"
+  packages = [
+    "grpc",
+    "services/authorize",
+    "services/hierarchy",
+    "services/iam",
+    "services/iot",
+    "services/pas",
+    "services/reports",
+  ]
+  pruneopts = "UT"
+  revision = "a743688aa8a2180b09ab31b47d36847ac3ffd17c"
+  version = "v1.14.2"
+
+[[projects]]
   digest = "1:769b04faeaec4069b22493a117b0b4f7799ebc8cfd2f0f4ddb7643cac7f21e00"
   name = "github.com/SKF/go-eventsource"
   packages = ["eventsource"]
@@ -22,7 +38,7 @@
   version = "v1.5.1"
 
 [[projects]]
-  digest = "1:8e5f09e7d85ad76660f1236d8f156ef55d5742cbb59a607f04969f38f9dccc66"
+  digest = "1:94265c85df4273a33255ab50eaf1d3135c8c78e2055d1fbf9d7ea8a070656f6d"
   name = "github.com/SKF/proto"
   packages = [
     "authorize",
@@ -34,8 +50,8 @@
     "reports",
   ]
   pruneopts = "UT"
-  revision = "5d3e8654b477007fad5459040fcf47a804242017"
-  version = "v1.17.0-go"
+  revision = "cefb251150248320cbc74a131c4963a49913e9a0"
+  version = "v1.19.0-go"
 
 [[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
@@ -243,6 +259,13 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/SKF/go-enlight-sdk/grpc",
+    "github.com/SKF/go-enlight-sdk/services/authorize",
+    "github.com/SKF/go-enlight-sdk/services/hierarchy",
+    "github.com/SKF/go-enlight-sdk/services/iam",
+    "github.com/SKF/go-enlight-sdk/services/iot",
+    "github.com/SKF/go-enlight-sdk/services/pas",
+    "github.com/SKF/go-enlight-sdk/services/reports",
     "github.com/SKF/go-eventsource/eventsource",
     "github.com/SKF/go-utility/env",
     "github.com/SKF/go-utility/log",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -35,7 +35,7 @@
 
 [[constraint]]
   name = "github.com/SKF/proto"
-  version = "1.18.0-go"
+  version = "1.19.0-go"
 
 [[constraint]]
   name = "github.com/stretchr/testify"

--- a/services/authorize/client.go
+++ b/services/authorize/client.go
@@ -62,11 +62,11 @@ type AuthorizeClient interface { // nolint: golint
 	RemoveResourceRelations(resources authorize_grpcapi.RemoveResourceRelationsInput) error
 	RemoveResourceRelationsWithContext(ctx context.Context, resources authorize_grpcapi.RemoveResourceRelationsInput) error
 
-	AddUserPermission(userID, action string, resource *common.Origin) error
-	AddUserPermissionWithContext(ctx context.Context, userID, action string, resource *common.Origin) error
+	ApplyUserAction(userID, action string, resource *common.Origin) error
+	ApplyUserActionWithContext(ctx context.Context, userID, action string, resource *common.Origin) error
 
-	RemoveUserPermission(userID, action string, resource *common.Origin) error
-	RemoveUserPermissionWithContext(ctx context.Context, userID, action string, resource *common.Origin) error
+	RemoveUserAction(userID, action string, resource *common.Origin) error
+	RemoveUserActionWithContext(ctx context.Context, userID, action string, resource *common.Origin) error
 
 	GetActionsByUserRole(userRole string) ([]authorize_grpcapi.Action, error)
 	GetActionsByUserRoleWithContext(ctx context.Context, userRole string) ([]authorize_grpcapi.Action, error)

--- a/services/authorize/functions.go
+++ b/services/authorize/functions.go
@@ -270,13 +270,13 @@ func (c *client) RemoveResourceRelationsWithContext(ctx context.Context, resourc
 	return err
 }
 
-func (c *client) AddUserPermission(userID, action string, resource *common.Origin) error {
+func (c *client) ApplyUserAction(userID, action string, resource *common.Origin) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
-	return c.AddUserPermissionWithContext(ctx, userID, action, resource)
+	return c.ApplyUserActionWithContext(ctx, userID, action, resource)
 }
-func (c *client) AddUserPermissionWithContext(ctx context.Context, userID, action string, resource *common.Origin) error {
-	_, err := c.api.AddUserPermission(ctx, &authorize_grpcapi.AddUserPermissionInput{
+func (c *client) ApplyUserActionWithContext(ctx context.Context, userID, action string, resource *common.Origin) error {
+	_, err := c.api.ApplyUserAction(ctx, &authorize_grpcapi.ApplyUserActionInput{
 		UserId:   userID,
 		Action:   action,
 		Resource: resource,
@@ -284,13 +284,13 @@ func (c *client) AddUserPermissionWithContext(ctx context.Context, userID, actio
 	return err
 }
 
-func (c *client) RemoveUserPermission(userID, action string, resource *common.Origin) error {
+func (c *client) RemoveUserAction(userID, action string, resource *common.Origin) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
-	return c.RemoveUserPermissionWithContext(ctx, userID, action, resource)
+	return c.RemoveUserActionWithContext(ctx, userID, action, resource)
 }
-func (c *client) RemoveUserPermissionWithContext(ctx context.Context, userID, action string, resource *common.Origin) error {
-	_, err := c.api.RemoveUserPermission(ctx, &authorize_grpcapi.RemoveUserPermissionInput{
+func (c *client) RemoveUserActionWithContext(ctx context.Context, userID, action string, resource *common.Origin) error {
+	_, err := c.api.RemoveUserAction(ctx, &authorize_grpcapi.RemoveUserActionInput{
 		UserId:   userID,
 		Action:   action,
 		Resource: resource,

--- a/services/authorize/mock/mock.go
+++ b/services/authorize/mock/mock.go
@@ -128,20 +128,20 @@ func (mock *client) RemoveResourceWithContext(ctx context.Context, resource comm
 	return args.Error(0)
 }
 
-func (mock *client) AddUserPermission(userID, action string, resource *common.Origin) error {
+func (mock *client) ApplyUserAction(userID, action string, resource *common.Origin) error {
 	args := mock.Called(userID, action, resource)
 	return args.Error(0)
 }
-func (mock *client) AddUserPermissionWithContext(ctx context.Context, userID, action string, resource *common.Origin) error {
+func (mock *client) ApplyUserActionWithContext(ctx context.Context, userID, action string, resource *common.Origin) error {
 	args := mock.Called(ctx, userID, action, resource)
 	return args.Error(0)
 }
 
-func (mock *client) RemoveUserPermission(userID, action string, resource *common.Origin) error {
+func (mock *client) RemoveUserAction(userID, action string, resource *common.Origin) error {
 	args := mock.Called(userID, action, resource)
 	return args.Error(0)
 }
-func (mock *client) RemoveUserPermissionWithContext(ctx context.Context, userID, action string, resource *common.Origin) error {
+func (mock *client) RemoveUserActionWithContext(ctx context.Context, userID, action string, resource *common.Origin) error {
 	args := mock.Called(ctx, userID, action, resource)
 	return args.Error(0)
 }


### PR DESCRIPTION
Change name of methods
1. AddUserPermission to ApplyUserAction 
2. RemoveUserPermission to RemoveUserAction
3. AddUserPermissionWithContext to ApplyUserActionWithContext 
4. RemoveUserPermissionWithContext to RemoveUserActionWithContext